### PR TITLE
adding service locator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
+# For consuming third party service providers
+gem 'httparty'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
@@ -48,6 +51,8 @@ group :test do
   gem 'faker'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
+  gem "vcr"
+  gem "webmock"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     base64 (0.2.0)
     bigdecimal (3.1.4)
     bootsnap (1.17.0)
@@ -83,6 +85,8 @@ GEM
     byebug (11.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
@@ -109,6 +113,10 @@ GEM
       i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashdiff (1.0.1)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -127,6 +135,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
+    multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-imap (0.4.7)
       date
@@ -146,6 +155,7 @@ GEM
       racc (~> 1.4)
     psych (5.1.1.1)
       stringio
+    public_suffix (5.0.4)
     puma (6.4.0)
       nio4r (~> 2.0)
     racc (1.7.3)
@@ -191,6 +201,7 @@ GEM
       psych (>= 4.0.0)
     reline (0.4.1)
       io-console (~> 0.5)
+    rexml (3.2.6)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -225,6 +236,11 @@ GEM
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    vcr (6.2.0)
+    webmock (3.19.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -244,6 +260,7 @@ DEPENDENCIES
   error_highlight (>= 0.4.0)
   factory_bot_rails
   faker
+  httparty
   puma (>= 5.0)
   rails (~> 7.1.2)
   rspec-rails
@@ -251,6 +268,8 @@ DEPENDENCIES
   simplecov
   sqlite3 (~> 1.4)
   tzinfo-data
+  vcr
+  webmock
 
 RUBY VERSION
    ruby 3.1.4p223

--- a/app/services/geolocator_service_provider.rb
+++ b/app/services/geolocator_service_provider.rb
@@ -1,0 +1,16 @@
+class GeolocatorServiceProvider
+
+  def initialize(access_credentials)
+    @access_credentials = access_credentials
+  end
+
+  def self.get_instance
+    configuration_map = YAML.load(ERB.new(File.read("#{Rails.root}/config/geolocator.yml")).result)
+    clazz = "#{configuration_map[Rails.env]["service_provider"]}ServiceProvider".constantize
+    clazz.new(configuration_map[Rails.env]["access_key"])
+  end
+
+  def fetch(_)
+    raise 'should be overriden'
+  end
+end

--- a/app/services/ip_stack_service_provider.rb
+++ b/app/services/ip_stack_service_provider.rb
@@ -9,16 +9,26 @@ class IpStackServiceProvider < GeolocatorServiceProvider
 
   def fetch(ip_address)
     response = self.class.get("/#{ip_address}?access_key=#{@access_credentials}&&hostname=1")
-    {
-      ip: response.parsed_response['ip'],
-      hostname: response.parsed_response['hostname'],
-      country_code: response.parsed_response['country_code'],
-      country_name: response.parsed_response['country_name'],
-      region_code: response.parsed_response['region_code'],
-      city: response.parsed_response['city'],
-      latitude: response.parsed_response['latitude'],
-      longitude: response.parsed_response['longitude']
-    }
+    if response.parsed_response['success'] == false
+      [ false,
+        {
+          error: response.parsed_response['error']['info']
+        }
+      ]
+    else
+      [ true,
+        {
+          ip: response.parsed_response['ip'],
+          hostname: response.parsed_response['hostname'],
+          country_code: response.parsed_response['country_code'],
+          country_name: response.parsed_response['country_name'],
+          region_code: response.parsed_response['region_code'],
+          city: response.parsed_response['city'],
+          latitude: response.parsed_response['latitude'],
+          longitude: response.parsed_response['longitude']
+       }
+      ]
+    end
   end
 
 end

--- a/app/services/ip_stack_service_provider.rb
+++ b/app/services/ip_stack_service_provider.rb
@@ -1,0 +1,24 @@
+class IpStackServiceProvider < GeolocatorServiceProvider
+  include HTTParty
+
+  base_uri 'api.ipstack.com'
+
+  def initialize(access_credentials)
+    super(access_credentials)
+  end
+
+  def fetch(ip_address)
+    response = self.class.get("/#{ip_address}?access_key=#{@access_credentials}&&hostname=1")
+    {
+      ip: response.parsed_response['ip'],
+      hostname: response.parsed_response['hostname'],
+      country_code: response.parsed_response['country_code'],
+      country_name: response.parsed_response['country_name'],
+      region_code: response.parsed_response['region_code'],
+      city: response.parsed_response['city'],
+      latitude: response.parsed_response['latitude'],
+      longitude: response.parsed_response['longitude']
+    }
+  end
+
+end

--- a/config/geolocator.yml
+++ b/config/geolocator.yml
@@ -1,0 +1,11 @@
+development:
+  service_provider: IpStack
+  access_key: <%= ENV.fetch("PROVIDER_KEY") { '' } %>
+
+test:
+  service_provider: IpStack
+  access_key: 'dummy_key'
+
+production:
+  service_provider: IpStack
+  access_key: <%= ENV.fetch("PROVIDER_KEY") { '' } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
 
-  resources :geolocations, only: [:index, :show] do
+  resources :geolocations, only: [:index, :show, :create] do
     get 'search_by', on: :collection
     delete 'destroy_by', on: :collection
   end

--- a/spec/cassettes/ipstack_bad_key.yml
+++ b/spec/cassettes/ipstack_bad_key.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.ipstack.com/142.30.1.4?access_key=bad_key&hostname=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; Charset=UTF-8
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Blocked-At-Loadbalancer:
+      - '1'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "success": false,
+          "error": {
+            "code": 101,
+            "type": "invalid_access_key",
+            "info": "You have not supplied a valid API Access Key. [Technical Support: support@apilayer.com]"
+          }
+        }
+  recorded_at: Sun, 10 Dec 2023 09:48:55 GMT
+recorded_with: VCR 6.2.0

--- a/spec/cassettes/ipstack_record.yml
+++ b/spec/cassettes/ipstack_record.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.ipstack.com/142.30.1.4?access_key=dummy_key&hostname=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Sun, 10 Dec 2023 08:52:03 GMT
+      X-Apilayer-Transaction-Id:
+      - a4305fd3-1603-447a-bd75-e2b66f135209
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS
+      Access-Control-Allow-Headers:
+      - "*"
+      X-Quota-Limit:
+      - '1000'
+      X-Quota-Remaining:
+      - '988'
+      X-Increment-Usage:
+      - '1'
+      X-Request-Time:
+      - '0.098'
+    body:
+      encoding: UTF-8
+      string: '{"ip": "142.30.1.4", "hostname": "142.30.1.4", "type": "ipv4", "continent_code":
+        "NA", "continent_name": "North America", "country_code": "CA", "country_name":
+        "Canada", "region_code": "BC", "region_name": "British Columbia", "city":
+        "Victoria", "zip": "V8X 4S8", "latitude": 48.45322036743164, "longitude":
+        -123.36897277832031, "location": {"geoname_id": 6174041, "capital": "Ottawa",
+        "languages": [{"code": "en", "name": "English", "native": "English"}, {"code":
+        "fr", "name": "French", "native": "Fran\u00e7ais"}], "country_flag": "https://assets.ipstack.com/flags/ca.svg",
+        "country_flag_emoji": "\ud83c\udde8\ud83c\udde6", "country_flag_emoji_unicode":
+        "U+1F1E8 U+1F1E6", "calling_code": "1", "is_eu": false}}'
+  recorded_at: Sun, 10 Dec 2023 08:52:03 GMT
+recorded_with: VCR 6.2.0

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,4 +62,11 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  VCR.configure do |config|
+    config.cassette_library_dir = "#{::Rails.root}/spec/cassettes"
+    config.hook_into :webmock
+    config.ignore_localhost = true
+    config.configure_rspec_metadata!
+  end
 end

--- a/spec/requests/geolocations_spec.rb
+++ b/spec/requests/geolocations_spec.rb
@@ -9,20 +9,12 @@ RSpec.describe "/geolocations", type: :request do
   let(:valid_attributes) {
     {
       ip: '142.30.1.4',
-      hostname: 'localhost',
-      country_code: 'us',
-      country_name: 'United States',
-      region_code: 'Ohio',
-      city: 'Columbus',
-      latitude: 39,
-      longitude: -82
     }
   }
 
   let(:invalid_attributes) {
     {
-      ip: 'x.x.x.x',
-      hostname: 'localhost',
+      ip: 'x.x.x.x'
     }
   }
 
@@ -101,20 +93,24 @@ RSpec.describe "/geolocations", type: :request do
   end
 
   # TODO: Comming soon when implementing service locator
-  xdescribe "POST /create" do
+  describe "POST /create" do
     context "with valid parameters" do
       it "creates a new Geolocation" do
-        expect {
-          post geolocations_url,
-               params: { geolocation: valid_attributes }, headers: valid_headers, as: :json
-        }.to change(Geolocation, :count).by(1)
+        VCR.use_cassette("ipstack_record") do
+          expect {
+            post geolocations_url,
+                 params: valid_attributes, headers: valid_headers, as: :json
+          }.to change(Geolocation, :count).by(1)
+        end
       end
 
       it "renders a JSON response with the new geolocation" do
-        post geolocations_url,
-             params: { geolocation: valid_attributes }, headers: valid_headers, as: :json
-        expect(response).to have_http_status(:created)
-        expect(response.content_type).to match(a_string_including("application/json"))
+        VCR.use_cassette("ipstack_record") do
+          post geolocations_url,
+               params: valid_attributes, headers: valid_headers, as: :json
+          expect(response).to have_http_status(:created)
+          expect(response.content_type).to match(a_string_including("application/json"))
+        end
       end
     end
 

--- a/spec/requests/geolocations_spec.rb
+++ b/spec/requests/geolocations_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "/geolocations", type: :request do
 
   let(:invalid_attributes) {
     {
-      ip: 'x.x.x.x'
+      fake_ip_attribute: 'x.x.x.x'
     }
   }
 
@@ -125,7 +125,7 @@ RSpec.describe "/geolocations", type: :request do
       it "renders a JSON response with errors for the new geolocation" do
         post geolocations_url,
              params: { geolocation: invalid_attributes }, headers: valid_headers, as: :json
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:not_found)
         expect(response.content_type).to match(a_string_including("application/json"))
       end
     end

--- a/spec/routing/geolocations_routing_spec.rb
+++ b/spec/routing/geolocations_routing_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe GeolocationsController, type: :routing do
       expect(get: "/geolocations/search_by").to route_to("geolocations#search_by")
     end
 
-    xit "routes to #create" do
+    it "routes to #create" do
       expect(post: "/geolocations").to route_to("geolocations#create")
     end
 

--- a/spec/services/geolocator_service_provider_spec.rb
+++ b/spec/services/geolocator_service_provider_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe GeolocatorServiceProvider do
+
+  context '#get_insance' do
+    subject { described_class.get_instance }
+
+    it 'returns the service locator defined in test section of geolocations.yml' do
+      expect(subject).to be_a IpStackServiceProvider
+    end
+  end
+
+  context '#fetch' do
+    let(:access_key) { 'dummy_key' }
+    subject { described_class.new(access_key) }
+
+    it 'cant be called from this class' do
+      expect{ subject.fetch('x') }.to raise_error(RuntimeError)
+    end
+  end
+end

--- a/spec/services/ip_stack_service_provider_spec.rb
+++ b/spec/services/ip_stack_service_provider_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe IpStackServiceProvider do
+  
+  let(:access_key) { 'dummy_key' }
+  subject { described_class.new(access_key) }
+
+  context 'with a correct key' do
+    let(:ip) { '142.30.1.4' }
+
+    it 'returns a valid response' do
+      VCR.use_cassette("ipstack_record") do
+        success, record = subject.fetch(ip)
+        expect(success).to be true
+        expect(record[:ip]).to eq('142.30.1.4')
+        [:city, :country_code, :country_name, :hostname, :ip, :latitude, :longitude, :region_code].each do |key|
+          expect(record[key]).to be_present
+        end
+      end
+    end
+  end
+
+  context 'with a incorrect key' do
+    let(:access_key) { 'bad_key' }
+    let(:ip) { '142.30.1.4' }
+
+    it 'returns a valid response' do
+      VCR.use_cassette("ipstack_bad_key") do
+        success, record = subject.fetch(ip)
+        expect(success).to be false
+        expect(record[:error]).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds service locator feature to be used when creating a new geolocation record. As suggested, my 3rd party provider is IPStack but it can be easily configured creating a serivce class extending `GeolocatorServiceProvider` and adjsuting file `config/geolocator.yml` as you can review in this PR.

This PR will only work fetching by ip.  Next PR will deal around allowing URLs to be considered.

Proper specs are added and IPStack requests are mocked using `vcr` gem.