### PR TITLE
ability to handle urls and ips

### DIFF
--- a/app/models/geolocation.rb
+++ b/app/models/geolocation.rb
@@ -3,8 +3,8 @@ require 'resolv'
 class Geolocation < ApplicationRecord
 
   validates :ip, presence: true, uniqueness: true
-  validates :hostname, presence: true, uniqueness: true
   validate :valid_ip
+  has_many :url_locations
 
   private
 
@@ -14,4 +14,16 @@ class Geolocation < ApplicationRecord
     end
   end
 
+  def self.locate_by(search_key, search_value)
+    chain = if search_value.blank?
+      Geolocation.none
+    elsif search_key == 'ip'
+      Geolocation.where(ip: search_value)
+    elsif search_key == 'url'
+      Geolocation.joins(:url_locations).where("url_locations.url = ?", search_value)
+    else
+      Geolocation.none
+    end
+    chain.first
+  end
 end

--- a/app/models/url_location.rb
+++ b/app/models/url_location.rb
@@ -1,0 +1,7 @@
+class UrlLocation < ApplicationRecord
+
+  belongs_to :geolocation, dependent: :destroy
+
+  validates :url, presence: true, uniqueness: true
+
+end

--- a/app/services/geolocator_creator_service.rb
+++ b/app/services/geolocator_creator_service.rb
@@ -1,0 +1,43 @@
+class GeolocatorCreatorService
+
+  attr_accessor :errors
+
+  def initialize(search_key, search_value)
+    @search_key = search_key
+    @search_value = search_value
+    @errors = []
+  end
+
+  # returns geolcation record to be created, otherwise returns nil
+  def store
+    return unless validate_params
+
+    service = GeolocatorServiceProvider.get_instance
+    success, result_from_call = service.fetch(@search_value)
+    unless success
+      @errors.concat(Array.wrap(result_from_call[:errors]))
+      return
+    end
+    geolocation = Geolocation.new
+    geolocation.assign_attributes(result_from_call)
+    geolocation.url_locations.build(url: @search_value) if @search_key == "url"
+    if geolocation.save
+      geolocation
+    else
+      @errors.concat(@geolocation.errors.map(&:full_message))
+    end
+  end
+
+  private
+
+  def validate_params
+    if @search_value.blank? || !@search_key.in?(%w[ip url])
+      @errors << "invalid parameters"
+    end
+    geolocation = Geolocation.locate_by(@search_key, @search_value)
+    if geolocation.present?
+      @errors << "record already exists"
+    end
+    @errors.count == 0
+  end
+end

--- a/app/services/ip_stack_service_provider.rb
+++ b/app/services/ip_stack_service_provider.rb
@@ -8,7 +8,7 @@ class IpStackServiceProvider < GeolocatorServiceProvider
   end
 
   def fetch(ip_address)
-    response = self.class.get("/#{ip_address}?access_key=#{@access_credentials}&&hostname=1")
+    response = self.class.get("/#{ip_address}?access_key=#{@access_credentials}")
     if response.parsed_response['success'] == false
       [ false,
         {
@@ -19,7 +19,6 @@ class IpStackServiceProvider < GeolocatorServiceProvider
       [ true,
         {
           ip: response.parsed_response['ip'],
-          hostname: response.parsed_response['hostname'],
           country_code: response.parsed_response['country_code'],
           country_name: response.parsed_response['country_name'],
           region_code: response.parsed_response['region_code'],

--- a/db/migrate/20231210210656_create_url_locations.rb
+++ b/db/migrate/20231210210656_create_url_locations.rb
@@ -1,0 +1,10 @@
+class CreateUrlLocations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :url_locations do |t|
+      t.string :url
+      t.integer :geolocation_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231210212106_remove_hostname_from_geolocations.rb
+++ b/db/migrate/20231210212106_remove_hostname_from_geolocations.rb
@@ -1,0 +1,5 @@
+class RemoveHostnameFromGeolocations < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :geolocations, :hostname
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_09_102126) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_10_212106) do
   create_table "geolocations", force: :cascade do |t|
     t.string "ip"
-    t.string "hostname"
     t.string "country_code"
     t.string "country_name"
     t.string "region_code"
@@ -22,8 +21,14 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_09_102126) do
     t.float "longitude"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["hostname"], name: "index_geolocations_on_hostname", unique: true
     t.index ["ip"], name: "index_geolocations_on_ip", unique: true
+  end
+
+  create_table "url_locations", force: :cascade do |t|
+    t.string "url"
+    t.integer "geolocation_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/spec/cassettes/ipstack_bad_key.yml
+++ b/spec/cassettes/ipstack_bad_key.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.ipstack.com/142.30.1.4?access_key=bad_key&hostname=1
+    uri: http://api.ipstack.com/142.30.1.4?access_key=bad_key
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/ipstack_positrace_record.yml
+++ b/spec/cassettes/ipstack_positrace_record.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.ipstack.com/www.positrace.com?access_key=dummy_key
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 11 Dec 2023 04:38:36 GMT
+      X-Apilayer-Transaction-Id:
+      - a085faa2-be8d-4a95-8564-5c7b0aa4c34d
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS
+      Access-Control-Allow-Headers:
+      - "*"
+      X-Quota-Limit:
+      - '1000'
+      X-Quota-Remaining:
+      - '983'
+      X-Increment-Usage:
+      - '1'
+      X-Request-Time:
+      - '0.030'
+    body:
+      encoding: UTF-8
+      string: '{"ip": "35.199.178.49", "type": "ipv4", "continent_code": "NA", "continent_name":
+        "North America", "country_code": "US", "country_name": "United States", "region_code":
+        "OR", "region_name": "Oregon", "city": "The Dalles", "zip": "97058", "latitude":
+        45.551700592041016, "longitude": -121.21900177001953, "location": {"geoname_id":
+        5756304, "capital": "Washington D.C.", "languages": [{"code": "en", "name":
+        "English", "native": "English"}], "country_flag": "https://assets.ipstack.com/flags/us.svg",
+        "country_flag_emoji": "\ud83c\uddfa\ud83c\uddf8", "country_flag_emoji_unicode":
+        "U+1F1FA U+1F1F8", "calling_code": "1", "is_eu": false}}'
+  recorded_at: Mon, 11 Dec 2023 04:38:36 GMT
+recorded_with: VCR 6.2.0

--- a/spec/cassettes/ipstack_record.yml
+++ b/spec/cassettes/ipstack_record.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.ipstack.com/142.30.1.4?access_key=dummy_key&hostname=1
+    uri: http://api.ipstack.com/142.30.1.4?access_key=dummy_key
     body:
       encoding: US-ASCII
       string: ''
@@ -42,7 +42,7 @@ http_interactions:
       - '0.098'
     body:
       encoding: UTF-8
-      string: '{"ip": "142.30.1.4", "hostname": "142.30.1.4", "type": "ipv4", "continent_code":
+      string: '{"ip": "142.30.1.4", "type": "ipv4", "continent_code":
         "NA", "continent_name": "North America", "country_code": "CA", "country_name":
         "Canada", "region_code": "BC", "region_name": "British Columbia", "city":
         "Victoria", "zip": "V8X 4S8", "latitude": 48.45322036743164, "longitude":

--- a/spec/factories/geolocation.rb
+++ b/spec/factories/geolocation.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :geolocation do
     ip { '127.0.0.1' }
-    hostname { 'localhost' }
     country_code { 'us' }
     country_name { 'United States'}
     region_code { 'Florida' }

--- a/spec/factories/url_location.rb
+++ b/spec/factories/url_location.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :url_location do
+    url { 'www.google.com' }
+    geolocation
+  end
+end

--- a/spec/models/url_location_spec.rb
+++ b/spec/models/url_location_spec.rb
@@ -1,26 +1,24 @@
 require 'rails_helper'
 
-RSpec.describe Geolocation, type: :model do
-
+RSpec.describe UrlLocation, type: :model do
   context "validations" do
     before do
-      FactoryBot.create(:geolocation, ip: '172.10.1.1')
+      FactoryBot.create(:url_location, url: 'myurl.com')
     end
-    subject { FactoryBot.build(:geolocation, ip: ip) }
+    subject { FactoryBot.build(:url_location, url: url) }
 
-    context "with a dupicated ip" do
-      let(:ip) { '172.10.1.1' }
+    context "with a dupicated url" do
+      let(:url) { 'myurl.com' }
 
       it 'is invalid' do
         expect(subject.valid?).to be false
-        expect(subject.errors.first.attribute).to eq(:ip)
+        expect(subject.errors.first.attribute).to eq(:url)
         expect(subject.errors.first.type).to eq(:taken)
       end
     end
 
-
     context "with a non duplicated record" do
-      let(:ip) { '170.0.31.11' }
+      let(:url) { 'myotherurl.com' }
 
       it 'is valid' do
         expect(subject.valid?).to be true

--- a/spec/requests/geolocations_spec.rb
+++ b/spec/requests/geolocations_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe "/geolocations", type: :request do
   # This should return the minimal set of attributes required to create a valid
   # Geolocation.
 
-  let!(:geolocation) { FactoryBot.create(:geolocation, ip: '172.10.1.1', hostname: 'myurl.com') }
+  let!(:geolocation) { FactoryBot.create(:geolocation, ip: '172.10.1.1') }
+  let!(:url_location) { FactoryBot.create(:url_location, geolocation: geolocation, url: 'www.google.com') }
 
   let(:valid_attributes) {
     {
-      ip: '142.30.1.4',
+      search_key: 'ip',
+      search_value: '142.30.1.4',
     }
   }
 
@@ -52,7 +54,8 @@ RSpec.describe "/geolocations", type: :request do
     context 'with an existing ip' do
       let(:params) do
         {
-          ip: '172.10.1.1'
+          search_value: '172.10.1.1',
+          search_key: 'ip'
         }
       end
 
@@ -63,10 +66,11 @@ RSpec.describe "/geolocations", type: :request do
       end
     end
 
-    context 'with an existing hostname' do
+    context 'with an existing url' do
       let(:params) do
         {
-          hostname: 'myurl.com'
+          search_key: 'url',
+          search_value: 'www.google.com'
         }
       end
 
@@ -80,7 +84,8 @@ RSpec.describe "/geolocations", type: :request do
     context 'with a non existing hostname' do
       let(:params) do
         {
-          hostname: 'yyy.com'
+          search_key: 'url',
+          search_value: 'yyy.com'
         }
       end
 
@@ -92,7 +97,6 @@ RSpec.describe "/geolocations", type: :request do
     end
   end
 
-  # TODO: Comming soon when implementing service locator
   describe "POST /create" do
     context "with valid parameters" do
       it "creates a new Geolocation" do
@@ -125,7 +129,7 @@ RSpec.describe "/geolocations", type: :request do
       it "renders a JSON response with errors for the new geolocation" do
         post geolocations_url,
              params: { geolocation: invalid_attributes }, headers: valid_headers, as: :json
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response.content_type).to match(a_string_including("application/json"))
       end
     end
@@ -135,35 +139,39 @@ RSpec.describe "/geolocations", type: :request do
     context 'with an existing ip' do
       let(:params) do
         {
-          ip: '172.10.1.1'
+          search_value: '172.10.1.1',
+          search_key: 'ip'
         }
       end
 
       it "destroys the requested geolocation" do
         expect {
           delete destroy_by_geolocations_url, params: params, headers: valid_headers, as: :json
-        }.to change(Geolocation, :count).by(-1)
+        }.to change(Geolocation, :count).by(-1).and change(UrlLocation, :count).by(-1)
       end
     end
 
-    context 'with an existing hostname' do
+    context 'with an existing url' do
       let(:params) do
         {
-          hostname: 'myurl.com'
+          search_key: 'url',
+          search_value: 'www.google.com'
         }
       end
 
       it "destroys the requested geolocation" do
         expect {
           delete destroy_by_geolocations_url, params: params, headers: valid_headers, as: :json
-        }.to change(Geolocation, :count).by(-1)
+        }.to change(Geolocation, :count).by(-1).and change(UrlLocation, :count).by(-1)
       end
     end
 
     context 'with a non existing hostname' do
       let(:params) do
         {
-          hostname: 'zzz.com'
+          search_key: 'url',
+          search_value: 'ttt.com'
+
         }
       end
 

--- a/spec/services/ip_stack_service_provider_spec.rb
+++ b/spec/services/ip_stack_service_provider_spec.rb
@@ -13,7 +13,7 @@ describe IpStackServiceProvider do
         success, record = subject.fetch(ip)
         expect(success).to be true
         expect(record[:ip]).to eq('142.30.1.4')
-        [:city, :country_code, :country_name, :hostname, :ip, :latitude, :longitude, :region_code].each do |key|
+        [:city, :country_code, :country_name, :ip, :latitude, :longitude, :region_code].each do |key|
           expect(record[key]).to be_present
         end
       end


### PR DESCRIPTION
This PR adds the abiloty to handle urls and ips seamlessly. For this:

- Add a new model to store urls
- An geolocator record may have 1..* url locators
- Removing `hostname` to save bandwith with positrace
- Creating new records is now done in a service class that is fully tested.